### PR TITLE
BUGFIX: pre-selection of cookies remains even if not consented

### DIFF
--- a/Classes/Domain/Service/CookieConsentService.php
+++ b/Classes/Domain/Service/CookieConsentService.php
@@ -197,6 +197,16 @@ class CookieConsentService
     }
 
     /**
+     * Checks if a user has a cookie consent.
+     *
+     * return bool
+     */
+    public function userHasCookieConsent()
+    {
+        return !is_null($this->consentCookie);
+    }
+
+    /**
      * Returns a sha1 hash from the cookie settings.
      *
      * @return string

--- a/Classes/Eel/Helper/CookieConsentHelper.php
+++ b/Classes/Eel/Helper/CookieConsentHelper.php
@@ -55,6 +55,16 @@ class CookieConsentHelper implements ProtectedContextAwareInterface
     }
 
     /**
+     * Checks if a user has a cookie consent.
+     *
+     * @return bool
+     */
+    public function userHasCookieConsent()
+    {
+        return $this->cookieConsentService->userHasCookieConsent();
+    }
+
+    /**
      * @param string $methodName
      * @return bool
      */

--- a/Resources/Private/Fusion/Component/Molecule/CookieBoxes.fusion
+++ b/Resources/Private/Fusion/Component/Molecule/CookieBoxes.fusion
@@ -21,7 +21,7 @@ prototype(Wysiwyg.CookieHandling:Component.Molecule.CookieBoxes) < prototype(Neo
             cookieGroupCheckbox = Wysiwyg.CookieHandling:Component.Atom.GroupCookieCheckbox {
                 groupKey = ${groupKey}
                 label = ${I18n.translate(group.label, group.label, [], 'CookieLayer', props.translationPackage, null, props.translationLocale)}
-                checked = ${group.defaultValue}
+                checked = ${CookieHandling.userHasCookieConsent() ? CookieHandling.cookieGroupIsAccepted(groupKey) : group.defaultValue}
                 disabled = ${group.readOnly}
             }
 


### PR DESCRIPTION
- added check for pre-selecting cookies, if a user has a consent to not pre-select if a user didn't consent for a specific group