### PR TITLE
Use configured domain for consent cookie(s)

### DIFF
--- a/Classes/Domain/Http/Middleware/CookieConsentMiddleware.php
+++ b/Classes/Domain/Http/Middleware/CookieConsentMiddleware.php
@@ -4,6 +4,7 @@ namespace Wysiwyg\CookieHandling\Domain\Http\Middleware;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Cookie;
+use Neos\Utility\ObjectAccess;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -19,10 +20,10 @@ class CookieConsentMiddleware implements MiddlewareInterface
     protected $cookieConsentService;
 
     /**
-     * @Flow\InjectConfiguration(path="consentCookieName")
-     * @var string
+     * @Flow\InjectConfiguration
+     * @var array
      */
-    protected $consentCookieName;
+    protected $configuration;
 
     /**
      * Loads the consent cookie, which has been set via the frontend.
@@ -42,8 +43,10 @@ class CookieConsentMiddleware implements MiddlewareInterface
 
         $cookies = $request->getCookieParams();
 
-        if (array_key_exists($this->consentCookieName, $cookies)) {
-            $consentCookie = new Cookie($this->consentCookieName, $cookies[$this->consentCookieName]);
+        $consentCookieName = $this->configuration['consentCookieName'];
+        if (array_key_exists($consentCookieName, $cookies)) {
+            $consentCookieDomain = ObjectAccess::getPropertyPath($this->configuration, 'cookieGroups.technical.cookies.cookie_consent.domain');
+            $consentCookie = new Cookie($consentCookieName, $cookies[$consentCookieName], 0, null, $consentCookieDomain);
             $this->cookieConsentService->setConsentCookie($consentCookie);
         }
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -12,6 +12,7 @@ Wysiwyg:
           cookie_consent:
             cookieName: 'cookieConsent'
             lifetime: '3 months'
+            domain: null
           cookie_accepted:
             cookieName: 'cookieConsentAccepted'
             lifetime: '3 months'

--- a/README.md
+++ b/README.md
@@ -1,40 +1,45 @@
 # wysiwyg* - Cookie Handling
- 
+
 ![Neos Package](https://img.shields.io/badge/Neos-Package-blue.svg "Neos Package")
 ![Flow Package](https://img.shields.io/badge/Flow-Package-orange.svg "Flow Package")
- 
-Neos component and jQuery to safely deal with cookies and make their handling conform with European law (GDPR).   
-This package provides simple and fast to use functions and a cookie layer. 
+
+Neos component and jQuery to safely deal with cookies and make their handling conform with European law (GDPR).
+This package provides simple and fast to use functions and a cookie layer.
 
 ## Documentation
 
 [Documentation](https://wysiwyg-software-design.github.io/Wysiwyg.CookieHandling)
 
 ## Installation
- 
+
 You can add this package via composer. Check the requirements and run the commands below.
 
 #### Requirements:
+
 - **PHP:** >= 7.3
 - **Neos:** >= 7.0
 
 #### Composer command:
+
 ```bash
 composer require wy/cookie-handling
 ```
 
 #### Apply migrations:
+
 ```bash
 ./flow flow:doctrine:migrate
 ```
 
 ## Contributing
+
 Pull requests are welcome. For major changes please open an issue first to discuss what you would like to change.
 
 ## Authors
-[Sven Wütherich](https://github.com/svwu)  
-[Alexander Schulte](https://github.com/Alex-Schulte)  
-[Eva-Maria Müller](https://github.com/emmue)  
+
+[Sven Wütherich](https://github.com/svwu)
+[Alexander Schulte](https://github.com/Alex-Schulte)
+[Eva-Maria Müller](https://github.com/emmue)
 [Marvin Kuhn](https://github.com/breadlesscode)
 
 ## License

--- a/Resources/Private/Fusion/Content/Config.fusion
+++ b/Resources/Private/Fusion/Content/Config.fusion
@@ -4,6 +4,7 @@ prototype(Wysiwyg.CookieHandling:Config) < prototype(Neos.Fusion:Component) {
     cookieLayerDisabled = ${q(documentNode).property('cookieLayerDisabled') ? 'true' : 'false'}
 
     consentCookieName = ${Configuration.setting('Wysiwyg.CookieHandling.cookieGroups.technical.cookies.cookie_consent.cookieName')}
+    consentCookieDomain = ${Configuration.setting('Wysiwyg.CookieHandling.cookieGroups.technical.cookies.cookie_consent.domain')}
     consentCookieLifetime = ${Configuration.setting('Wysiwyg.CookieHandling.cookieGroups.technical.cookies.cookie_consent.lifetime')}
     consentCookieAcceptedName = ${Configuration.setting('Wysiwyg.CookieHandling.cookieGroups.technical.cookies.cookie_accepted.cookieName')}
     consentCookieAcceptedLifetime = ${Configuration.setting('Wysiwyg.CookieHandling.cookieGroups.technical.cookies.cookie_accepted.lifetime')}
@@ -26,6 +27,11 @@ prototype(Wysiwyg.CookieHandling:Config) < prototype(Neos.Fusion:Component) {
             consentCookieName = Wysiwyg.CookieHandling:Component.Atom.CookieSetting {
                 key = 'consentCookieName'
                 value = ${props.consentCookieName}
+            }
+
+            consentCookieDomain = Wysiwyg.CookieHandling:Component.Atom.CookieSetting {
+                key = 'consentCookieDomain'
+                value = ${props.consentCookieDomain}
             }
 
             consentCookieLifetime = Wysiwyg.CookieHandling:Component.Atom.CookieSetting {

--- a/Resources/Public/Javascript/CookieHandling.js
+++ b/Resources/Public/Javascript/CookieHandling.js
@@ -15,7 +15,8 @@ WY.CookieHandling = {
         cookieLayerSelector: '#cookieLayer',
         cookieSuffix: '_cookies',
         consentCookieName: 'cookieConsent',
-        cookieConsentChangedEventName: 'cookieConsentChanged',
+        consentCookieDomain: null,
+        cookieConsentChangedEventName: 'cookieConsentChanged'
     },
 
     /**
@@ -228,12 +229,13 @@ WY.CookieHandling = {
      *
      * @param cookieName
      * @param cookieValue
-     * @param path
+     * @param path - is ignored!
      * @param expireDays
+     * @param domain
      */
-    tryAddCookie: function (cookieName, cookieValue, path, expireDays) {
+    tryAddCookie: function (cookieName, cookieValue, path, expireDays, domain) {
         if (this.cookieIsAccepted(cookieName)) {
-            this._setCookie(cookieName, cookieValue, expireDays);
+            this._setCookie(cookieName, cookieValue, expireDays, domain);
         }
     },
 
@@ -245,12 +247,17 @@ WY.CookieHandling = {
      * @param cookieName - cookie name
      * @param cookieValue - cookie value
      * @param expireDays - expiry in days
+     * @param domain - domain to use, optional
      */
-    _setCookie: function (cookieName, cookieValue, expireDays) {
+    _setCookie: function (cookieName, cookieValue, expireDays, domain) {
         var date = new Date();
         date.setTime(date.getTime() + (expireDays * 24 * 60 * 60 * 1000));
         var expires = "expires=" + date.toUTCString();
-        document.cookie = cookieName + "=" + cookieValue + ";" + expires + ";path=/";
+        var cookie = cookieName + "=" + cookieValue + ";" + expires + ";path=/";
+        if (domain !== null) {
+            cookie += ";domain=" + domain;
+        }
+        document.cookie = cookie;
     },
 
     /**
@@ -325,8 +332,8 @@ WY.CookieHandling = {
         var previousCookieValue = this._getCookie(this.settings.consentCookieName);
         var newCookieValue = encodeURIComponent(JSON.stringify(this.consentCookie));
 
-        this._setCookie(this.settings.consentCookieName, newCookieValue, this.getExpireDaysForTimeString(this.settings.consentCookieLifeTime));
-        this._setCookie(this.settings.consentCookieAcceptedName, this.settings.consentCookieVersion, this.getExpireDaysForTimeString(this.settings.cookieConsentAcceptedLifetime));
+        this._setCookie(this.settings.consentCookieName, newCookieValue, this.getExpireDaysForTimeString(this.settings.consentCookieLifeTime), this.settings.consentCookieDomain);
+        this._setCookie(this.settings.consentCookieAcceptedName, this.settings.consentCookieVersion, this.getExpireDaysForTimeString(this.settings.cookieConsentAcceptedLifetime), this.settings.consentCookieDomain);
 
         if (previousCookieValue !== newCookieValue) {
             var event;
@@ -399,6 +406,7 @@ WY.CookieHandling = {
         this.consentCookie = JSON.parse(savedCookie);
         this.cookieSettings = JSON.parse(document.cookieHandling.cookieSettings);
         this.settings.consentCookieName = document.cookieHandling.consentCookieName;
+        this.settings.consentCookieDomain = document.cookieHandling.consentCookieDomain;
         this.settings.consentCookieLifeTime = document.cookieHandling.consentCookieLifeTime;
         this.settings.consentCookieAcceptedName = document.cookieHandling.consentCookieAcceptedName;
         this.settings.consentCookieAcceptedLifetime = document.cookieHandling.consentCookieAcceptedLifetime;


### PR DESCRIPTION
This sets the consent cookie using the domain configured for the `cookie_consent` cookie.

This allows for domain-wide use of the cookie acceptance.