### PR TITLE
Use configured cookie name(s) in JS on the client side

### DIFF
--- a/Resources/Public/Javascript/CookieHandling.js
+++ b/Resources/Public/Javascript/CookieHandling.js
@@ -402,8 +402,6 @@ WY.CookieHandling = {
             return;
         }
 
-        var savedCookie = this._getCookie(this.settings.consentCookieName) || '{}';
-        this.consentCookie = JSON.parse(savedCookie);
         this.cookieSettings = JSON.parse(document.cookieHandling.cookieSettings);
         this.settings.consentCookieName = document.cookieHandling.consentCookieName;
         this.settings.consentCookieDomain = document.cookieHandling.consentCookieDomain;
@@ -411,5 +409,7 @@ WY.CookieHandling = {
         this.settings.consentCookieAcceptedName = document.cookieHandling.consentCookieAcceptedName;
         this.settings.consentCookieAcceptedLifetime = document.cookieHandling.consentCookieAcceptedLifetime;
         this.settings.consentCookieVersion = document.cookieHandling.consentCookieVersion;
+        var savedCookie = this._getCookie(this.settings.consentCookieName) || '{}';
+        this.consentCookie = JSON.parse(savedCookie);
     }
 };

--- a/Resources/Public/Javascript/CookieLayer.js
+++ b/Resources/Public/Javascript/CookieLayer.js
@@ -288,6 +288,7 @@ WY.CookieLayer = {
 
         if (this.elements.cookieLayerElement.length) {
             WY.CookieHandling.init();
+            this.settings.cookieName = document.cookieHandling.consentCookieAcceptedName;
 
             this.cookieSettings = JSON.parse(document.cookieHandling.cookieSettings);
             this.options.cookieLayerIsDisabled = document.cookieHandling.cookieLayerDisabled;


### PR DESCRIPTION
Without this, a change to the default cookie name(s) would result in the cookie layer being shown on every request, since the settings were parsed after being used – or not read at all.